### PR TITLE
feat: implement sealed exception hierachy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 # A high-concurrency java 21 service designed to aggregate and normalize literary metadata from various external APIs
 
 ## Current Status
--  **Phase 1: Foundation and Single-Source Integration**
-    - [x] Initialize project structure and maven wrapper
-    - [x] Implement Jackson Infrastructure
-    - [ ] Integrate Google Books API 
-
+- **Phase 2:** Service Layer and Multi-Source Integration.
+  - [ ] Initialize Service Layer Architecture
+  - [ ] Implement Exhaustive Error Logic
+  - [ ] Integrate OpenLibrary API
 ## Built with
 - **Java 21(LTS)** - Utilizing Records and Virtual Threads. 
 
@@ -32,14 +31,27 @@ allowing these sources to be normalized into a unified data model.
 -  Implement Project Loom (Virtual Threads) to enable concurrent multi-source aggregation
 
 ## Roadmap
-- **Phase 2:** Spring Boot 3 Migration & PostgreSQL Persistence.
+- **Phase 3:** Spring Boot 3 Migration & PostgreSQL Persistence.
+<!--
+- [ ] Wrap the functional core into managed Spring service and component beans.
+- [ ] Spin up a physical database engine and implement Spring Data repositories to transition from memory storage to permanent data tracking.
+-->
 
+- **Phase 4:** High-Concurrency implementation through **Project Loom**.
+<!-- 
+- [ ] Virtual Threads Integration: Configure concurrent execution pipelines to fetch data from your multiple API sources simultaneously without blocking execution threads.
+-->
 
-- **Phase 3:** High-Concurrency implementation through **Project Loom**.
+- **Phase 5:** Distributed messaging with **Apache Kafka**.
+<!-- 
+- [ ]Introduce Apache Kafka brokers to publish integration events whenever books are successfully aggregated or a data integrity failure occurs.
+-->
 
-
-- **Phase 4:** Distributed messaging with **Apache Kafka**.
-
+## Previous Phases
+   **Phase 1: Foundation and Single-Source Integration**
+   - [x] Initialize project structure and maven wrapper
+   - [x] Implement Jackson Infrastructure
+   - [x] Integrate Google Books API
 ## How to run
 1. Clone the repository.
 2. Run `./mvnw clean install` (or `./mvnw.cmd clean install` on Windows).

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/BookAggregatorException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/BookAggregatorException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public abstract sealed class BookAggregatorException extends RuntimeException permits DataIntegrityException, ServiceAccessException  {
+    public BookAggregatorException(String message) {
+        super(message);
+    }
+
+    public BookAggregatorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/DataIntegrityException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/DataIntegrityException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public sealed class DataIntegrityException extends BookAggregatorException permits ISBNResolutionException, SieveFailureException {
+    public DataIntegrityException(String message) {
+        super(message);
+    }
+
+    public DataIntegrityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/ISBNResolutionException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/ISBNResolutionException.java
@@ -1,0 +1,10 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public final class ISBNResolutionException extends DataIntegrityException {
+    public ISBNResolutionException(String message) {
+        super(message);
+    }
+    public ISBNResolutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/PersistenceFailureException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/PersistenceFailureException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public final class PersistenceFailureException extends ServiceAccessException {
+    public PersistenceFailureException(String message) {
+        super(message);
+    }
+
+    public PersistenceFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public final class ResourceNotFoundException extends ServiceAccessException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/ServiceAccessException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/ServiceAccessException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public sealed class ServiceAccessException extends BookAggregatorException permits ResourceNotFoundException, PersistenceFailureException {
+    public ServiceAccessException(String message) {
+        super(message);
+    }
+
+    public ServiceAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dc/bookaggregator/domain/exceptions/SieveFailureException.java
+++ b/src/main/java/com/dc/bookaggregator/domain/exceptions/SieveFailureException.java
@@ -1,0 +1,11 @@
+package com.dc.bookaggregator.domain.exceptions;
+
+public final class SieveFailureException extends DataIntegrityException {
+    public SieveFailureException(String message) {
+        super(message);
+    }
+
+    public SieveFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- Define abstract sealed BookAggregatorException extending RuntimeException.
- Implement intermediate sealed DataIntegrityException and ServiceAccessException.
- Create final leaves for ISBNResolution, SieveFailure, ResourceNotFound, and PersistenceFailure.
- Enforce dual-constructor contracts across all 7 files to preserve Throwable causes.